### PR TITLE
Contact link fix

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -38,7 +38,7 @@
               %li{class: nav_active('dashboard')}= link_to 'Dashboard', dashboard_path
             %li{class: nav_active('portfolios')}= link_to 'All Portfolios', '/'
             %li{class: nav_active('main')}= link_to 'Main Site', 'http://turing.io'
-            %li{class: nav_active('contact')}=    link_to 'Contact', '/contact'
+            %li{class: nav_active('contact')}=    link_to 'Contact', 'http://turing.io/contact
             - if logged_in?
               %li= link_to 'Logout', logout_path
 


### PR DESCRIPTION
Contact currently linking to nowhere, either add a route/view or pass it on to the main site.