### PR TITLE
Adds an order_by_state_and_city method to the location model

### DIFF
--- a/app/controllers/location_interests_controller.rb
+++ b/app/controllers/location_interests_controller.rb
@@ -5,7 +5,7 @@ class LocationInterestsController < ApplicationController
 
   def new
     @location_interest = current_person.location_interests.new
-    @additional_locations = Location.all - current_person.locations
+    @additional_locations = Location.order_by_state_and_city - current_person.locations
   end
 
   def build_location_and_interest

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,4 +12,8 @@ class Location < ActiveRecord::Base
   def self.active
     order("split_part(name, ', ', 2)").where('locations.location_interests_count > 0')
   end
+
+  def self.order_by_state_and_city
+    order("split_part(name, ', ', 2), split_part(name, ', ', 1)")
+  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Location, :type => :model do
     { name: "Denver" }
   end
 
-  context "when given correct data" do    
+  context "when given correct data" do
     it "is created" do
       result = Location.create(data)
-      
+
       expect(result).to be_valid
     end
 
@@ -42,9 +42,20 @@ RSpec.describe Location, :type => :model do
       result = Location.create(data)
       expect(result.people).not_to be_nil
     end
+
+    it "returns the locations sorted by city and state" do
+      locations = ["Denver, CO", "Sydney, Australia", "San Francisco, CA", "Remote"]
+      locations.each_with_index.map do |name, index|
+        Location.create(name: name, location_interests_count: index)
+      end
+
+      result = ["Remote", "Sydney, Australia", "San Francisco, CA", "Denver, CO"]
+
+      expect(result).to eq Location.order_by_state_and_city.map(&:name)
+    end
   end
 
-  context "when given incorrect data" do 
+  context "when given incorrect data" do
     it "is invalid without a name" do
       result = Location.create
 


### PR DESCRIPTION
Locations are now sorted on the `/location_interests/new` page.

Before:
![image](https://cloud.githubusercontent.com/assets/6809782/7944202/80f5d674-0926-11e5-8be9-6eaecf49abad.png)

After:
![image](https://cloud.githubusercontent.com/assets/6809782/7944218/9997a2d4-0926-11e5-95a3-ffe3265ad5b0.png)

closes #31 

