### PR TITLE
Add url validations to url fields in Project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,9 @@
 class Project < ActiveRecord::Base
   belongs_to :person
   mount_uploader :screenshot, ScreenshotUploader
+
+  validates_format_of :github_url,              with: URI.regexp, if: Proc.new { |p| p.github_url.present? }
+  validates_format_of :code_climate_badge_url,  with: URI.regexp, if: Proc.new { |p| p.code_climate_badge_url.present? }
+  validates_format_of :travis_ci_badge_url,     with: URI.regexp, if: Proc.new { |p| p.travis_ci_badge_url.present? }
+  validates_format_of :production_url,          with: URI.regexp, if: Proc.new { |p| p.production_url.present? }
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Project, type: :model do
       {
         title:                  'title',
         description:            'description',
-        github_url:             'http://example.com/github',
+        github_url:             'https://example.com/github',
         my_focus:               'programming',
         code_climate_badge_url: 'http://example.com/code-climate',
         travis_ci_badge_url:    'http://example.com/travis-ci',
@@ -21,7 +21,7 @@ RSpec.describe Project, type: :model do
       expect(result).to                        be_valid
       expect(result.title).to                  eq 'title'
       expect(result.description).to            eq 'description'
-      expect(result.github_url).to             eq 'http://example.com/github'
+      expect(result.github_url).to             eq 'https://example.com/github'
       expect(result.my_focus).to               eq 'programming'
       expect(result.code_climate_badge_url).to eq 'http://example.com/code-climate'
       expect(result.travis_ci_badge_url).to    eq 'http://example.com/travis-ci'
@@ -37,6 +37,73 @@ RSpec.describe Project, type: :model do
 
       expect(result.person).not_to be_nil
       expect(result.person).to eq person
+    end
+  end
+
+  context 'when given bad data' do
+    let(:data) do
+      {
+        title:                  'title',
+        description:            'description',
+        github_url:             'example.com/github',
+        my_focus:               'programming',
+        code_climate_badge_url: 'example.com/code-climate',
+        travis_ci_badge_url:    'example.com/travis-ci',
+        screenshot:             'screenshot',
+        production_url:         'example.com/production'
+      }
+    end
+
+    it 'does not allow invalid urls for github' do
+      project = Project.new(data)
+
+      expect(project).not_to  be_valid
+      expect(project.errors.messages).to include :github_url
+    end
+    it 'does allow for an empty github url' do
+      project = Project.new(data)
+      project.github_url = nil
+
+      expect(project.errors.messages).not_to  include :github_url
+    end
+
+    it 'does not allow invalid urls for code climate badge' do
+      project = Project.new(data)
+
+      expect(project).not_to  be_valid
+      expect(project.errors.messages).to include :code_climate_badge_url
+    end
+    it 'does allow for an empty code climate badge url' do
+      project = Project.new(data)
+      project.code_climate_badge_url = nil
+
+      expect(project.errors.messages).not_to  include :code_climate_badge_url
+    end
+
+    it 'does not allow invalid urls for travis ci' do
+      project = Project.new(data)
+
+      expect(project).not_to  be_valid
+      expect(project.errors.messages).to include :travis_ci_badge_url
+    end
+    it 'does allow for an empty travis ci url' do
+      project = Project.new(data)
+      project.travis_ci_badge_url = nil
+
+      expect(project.errors.messages).not_to  include :travis_ci_badge_url
+    end
+
+    it 'does not allow invalid urls for production' do
+      project = Project.new(data)
+
+      expect(project).not_to  be_valid
+      expect(project.errors.messages).to include :production_url
+    end
+    it 'does allow for an empty production url' do
+      project = Project.new(data)
+      project.production_url = nil
+
+      expect(project.errors.messages).not_to  include :production_url
     end
   end
 end


### PR DESCRIPTION
Hi TuringSchool...you all look like some great people...but even great people don't follow prompts when filling out forms.

I ran across a profile that looked like it linked out github, but instead ended up being a relative link because the full url was not included when the `Project` was created. (The `http://` as omitted...it happens.)

![relative_url](https://cloud.githubusercontent.com/assets/1148/10679867/e9f143b4-78e0-11e5-8cc1-124e894c55d2.png)

This PR adds format validation to all the `*_url` fields on the `Project` model to ensure they are indeed qualified URLs. (This validation is not performed if the field is `nil`) A set of specs accompany.

Caveat: I don't really code on a regular basis anymore, so I'm unsure if `validates_format_of` is still en vogue or if the more generic `validates` is what the cool kids are doing.